### PR TITLE
feat(user):로그인 유저, 트레이너 정보 추가 가능/GYMMATE-253

### DIFF
--- a/src/apis/userApi.ts
+++ b/src/apis/userApi.ts
@@ -1,0 +1,28 @@
+import { UserData } from '@/types/UserData';
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+export const registerUser = async (userData: UserData) => {
+  try {
+    const response = await fetch(`${API_BASE_URL}/user/register`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
+      },
+      body: JSON.stringify(userData),
+      credentials: 'include',
+    });
+
+    if (response.ok) {
+      return await response.json();
+    } else {
+      const error = await response.json();
+
+      throw new Error(error.message || '회원가입에 실패하였습니다.');
+    }
+  } catch (error) {
+    console.error('회원가입 실패:', error);
+    throw error;
+  }
+};

--- a/src/components/molecules/AddressInput/index.tsx
+++ b/src/components/molecules/AddressInput/index.tsx
@@ -1,12 +1,17 @@
 'use client';
 
 import React, { useState, ChangeEvent } from 'react';
-import InputField from '@/app/login/components/InputField';
 import { MagnifyingGlassIcon } from '@heroicons/react/24/outline';
+
+import InputField from '@/app/login/components/InputField';
 import AddressSearchModal from '@/components/molecules/AddressSearchModal/AddressSearchModal';
 
-const AddressInput = () => {
-  const [address, setAddress] = useState('');
+interface AddressInputProps {
+  setAddress: React.Dispatch<React.SetStateAction<string>>; // setAddress의 타입 정의
+}
+
+const AddressInput = ({ setAddress }: AddressInputProps) => {
+  const [address, setLocalAddress] = useState(''); // 내부 주소 상태 관리
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   // 모달 열기 함수
@@ -16,35 +21,38 @@ const AddressInput = () => {
 
   // 모달에서 주소 선택 시
   const handleAddressSelect = (selectedAddress: string) => {
-    setAddress(selectedAddress);
+    setLocalAddress(selectedAddress); // 선택한 주소를 로컬 상태에 저장
+    setAddress(selectedAddress); // 부모 컴포넌트에 주소 전달
     setIsModalOpen(false);
   };
 
-  // 직접 입력 시 (원한다면 readOnly 없이도 가능)
+  // 직접 입력 시
   const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
-    setAddress(e.target.value);
+    setLocalAddress(e.target.value);
+    setAddress(e.target.value); // 부모 컴포넌트에 주소 전달
   };
 
   return (
     <div className="relative">
       <button
-        type="button"
-        onClick={handleOpenModal}
         aria-label="주소 검색"
         className="w-full"
+        type="button"
+        onClick={handleOpenModal}
       >
         <InputField
+          readOnly
+          containerMarginBottom="60px"
+          height="40px"
           label="도로명 주소"
+          labelInputGap="8px"
           name="address"
           placeholder="예: 서울시 강남구 ..."
           required={true}
-          width="452px"
-          height="40px"
-          containerMarginBottom="60px"
-          labelInputGap="8px"
+          type="text"
           value={address}
+          width="452px"
           onChange={handleInputChange}
-          readOnly
         />
       </button>
       <MagnifyingGlassIcon

--- a/src/components/molecules/ExerciseInputs/index.tsx
+++ b/src/components/molecules/ExerciseInputs/index.tsx
@@ -1,23 +1,42 @@
 import InputField from '@/app/login/components/InputField';
 
 const exercises = [
-  { label: '스쿼트', name: 'squat' },
-  { label: '데드리프트', name: 'deadlift' },
-  { label: '벤치프레스', name: 'benchpress' },
+  { label: '스쿼트', name: 'recentSquat' },
+  { label: '데드리프트', name: 'recentDeadlift' },
+  { label: '벤치프레스', name: 'recentBench' },
 ];
 
-const ExerciseInputs = () => (
+interface ExerciseInputsProps {
+  setExerciseData: React.Dispatch<
+    React.SetStateAction<{
+      recentBench: number;
+      recentSquat: number;
+      recentDeadlift: number;
+    }>
+  >;
+}
+
+const ExerciseInputs = ({ setExerciseData }: ExerciseInputsProps) => (
   <div className="flex gap-4 mb-6">
     {exercises.map(({ label, name }) => (
       <InputField
         key={name}
+        containerMarginBottom="60px"
+        height="40px"
         label={label}
+        labelInputGap="5px"
         name={name}
         placeholder="KG"
+        type="number"
         width="141px"
-        height="40px"
-        containerMarginBottom="60px"
-        labelInputGap="5px"
+        onChange={(e) => {
+          const value = Number(e.target.value); // 숫자로 변환
+
+          setExerciseData((prev) => ({
+            ...prev,
+            [name]: value,
+          }));
+        }}
       />
     ))}
   </div>

--- a/src/components/molecules/MeasurementInput/index.tsx
+++ b/src/components/molecules/MeasurementInput/index.tsx
@@ -1,30 +1,56 @@
 import InputField from '@/app/login/components/InputField';
+import { UserData } from '@/types/UserData'; // UserData 타입 임포트
 
-const MeasurementInputs = () => (
-  <div className="flex gap-[74px] ">
-    <InputField
-      label="키"
-      name="height"
-      placeholder="예: 170cm"
-      required
-      width="234px"
-      height="40px"
-      className="flex-1"
-      containerMarginBottom="60px"
-      labelInputGap="5px"
-    />
-    <InputField
-      label="몸무게"
-      name="weight"
-      placeholder="예: 60kg"
-      required
-      width="141px"
-      height="40px"
-      className="flex-1"
-      containerMarginBottom="60px"
-      labelInputGap="5px"
-    />
-  </div>
-);
+interface MeasurementInputsProps {
+  formData: UserData; // 부모에서 전달받는 formData 타입
+  setFormData: React.Dispatch<React.SetStateAction<UserData>>; // setFormData 타입
+}
+
+const MeasurementInputs = ({
+  formData,
+  setFormData,
+}: MeasurementInputsProps) => {
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+
+    setFormData((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
+  };
+
+  return (
+    <div className="flex gap-[74px] ">
+      <InputField
+        required
+        className="flex-1"
+        containerMarginBottom="60px"
+        height="40px"
+        label="키"
+        labelInputGap="5px"
+        name="height" // name을 키로 설정
+        placeholder="예: 170cm"
+        type="text"
+        value={formData.height} // 부모에서 받은 값을 설정
+        width="234px"
+        onChange={handleInputChange} // 입력값 변경 시 상위 상태 업데이트
+      />
+      <InputField
+        required
+        className="flex-1"
+        containerMarginBottom="60px"
+        height="40px"
+        label="몸무게"
+        labelInputGap="5px"
+        name="weight" // name을 몸무게로 설정
+        placeholder="예: 60kg"
+        type="text"
+        value={formData.weight} // 부모에서 받은 값을 설정
+        width="141px"
+        onChange={handleInputChange} // 입력값 변경 시 상위 상태 업데이트
+      />
+    </div>
+  );
+};
 
 export default MeasurementInputs;

--- a/src/components/templates/LoginTemplate/UserLoginOne/index.tsx
+++ b/src/components/templates/LoginTemplate/UserLoginOne/index.tsx
@@ -1,9 +1,11 @@
 import { useState } from 'react';
 
+import { formatDate } from '@/utils/formatUtils';
 import InputField from '@/app/login/components/InputField';
 import BirthdayInputGroup from '@/components/molecules/BirthdayInputGroup';
 import CustomButton from '@/app/login/components/CustomButton';
 import ReturnHomeMessage from '@/app/login/components/HomeLink/HomeReturnMsg';
+
 interface Step1FormProps {
   setFormData: React.Dispatch<React.SetStateAction<any>>;
   setStep: React.Dispatch<React.SetStateAction<number>>;
@@ -19,8 +21,14 @@ export default function Step1Form({ setFormData, setStep }: Step1FormProps) {
 
     if (!birth) {
       alert('모든 필드 선택해주세요.');
+
+      return;
     }
-    setFormData({ ...result, birth });
+
+    // 생년월일 포매팅 ('YYYYMMDD' 형식으로 변환)
+    const formattedBirth = formatDate(birth);
+
+    setFormData({ ...result, birth: formattedBirth });
     setStep(2);
   };
 

--- a/src/types/UserData.ts
+++ b/src/types/UserData.ts
@@ -1,0 +1,13 @@
+export interface UserData {
+  phoneNumber: string; // 필수
+  memberName: string; // 필수
+  email: string; // 필수
+  birthday: string; // 필수
+  gender: string; // 필수
+  height: string; // 필수
+  weight: string; // 필수
+  address: string; // 필수
+  recentBench: number; // 선택
+  recentSquat: number; // 선택
+  recentDeadlift: number; // 선택
+}


### PR DESCRIPTION
# 📝 제목

feat(user):로그인 유저, 트레이너 정보 추가 가능

---

## 🔘 Part

- feat(user)

---

## 🔎 작업 내용

- 로그인 시 유저 정보 등록 가능  | ( 헬스장 직원, 사장 등록 완료 )
---

## 🖼️ 이미지 첨부
![스크린샷 2025-04-01 15 11 45](https://github.com/user-attachments/assets/682f6518-8c4c-4579-9142-0602b7dcf82b)


---

## 🔄 체크리스트

- [x] 기존 기능 영향 없음
- [x] 실행 문제 없음
- [ ] 테스트 완료

---

## 🙏 리뷰 요청 사항

- 추후 백엔드 코드 완성시 연동 필요함

---

## 🔧 앞으로의 과제

- 유저 정보 저장, 3대 운동 페이지

---

## ➕ 이슈 링크

- #14 (자동 링크)

---
