### PR TITLE
shop(feat) : 상품 샵 퍼블리싱 및 aip 연동/GYMMATE-280

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
 # dependencies
+/.env
 /node_modules
 /.pnp
 .pnp.js

--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,8 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  images: {
+    domains: ['shopping-phinf.pstatic.net'],
+  },
+};
 
 module.exports = nextConfig;

--- a/src/apis/naverShoppingApi.ts
+++ b/src/apis/naverShoppingApi.ts
@@ -1,0 +1,13 @@
+export const fetchNaverShopping = async (
+  query: string,
+  start = 1,
+  display = 5,
+) => {
+  const res = await fetch(
+    `/api/naver/search?query=${encodeURIComponent(query)}&start=${start}&display=${display}`,
+  );
+
+  if (!res.ok) throw new Error('네이버 쇼핑 API 실패');
+
+  return res.json();
+};

--- a/src/app/api/naver/search/route.ts
+++ b/src/app/api/naver/search/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const NAVER_CLIENT_ID = process.env.NEXT_PUBLIC_NAVER_CLIENT_ID!;
+const NAVER_CLIENT_SECRET = process.env.NEXT_PUBLIC_NAVER_CLIENT_SECRET!;
+
+export const GET = async (req: NextRequest) => {
+  try {
+    const { searchParams } = new URL(req.url);
+
+    const query = searchParams.get('query');
+    const start = searchParams.get('start') || '1';
+    const display = searchParams.get('display') || '10';
+
+    if (!query) {
+      return NextResponse.json({ error: '쿼리 없음' }, { status: 400 });
+    }
+
+    const res = await fetch(
+      `https://openapi.naver.com/v1/search/shop.json?query=${encodeURIComponent(query)}&display=${display}&start=${start}`,
+      {
+        headers: {
+          'X-Naver-Client-Id': NAVER_CLIENT_ID,
+          'X-Naver-Client-Secret': NAVER_CLIENT_SECRET,
+        },
+      },
+    );
+
+    const rawText = await res.text();
+
+    // 여기서 파싱 시도
+    let data;
+
+    try {
+      data = JSON.parse(rawText);
+    } catch (parseError) {
+      console.error(' JSON 파싱 실패:', parseError);
+
+      return NextResponse.json({ error: 'JSON 파싱 실패' }, { status: 500 });
+    }
+
+    if (!res.ok) {
+      return NextResponse.json(
+        { error: data?.errorMessage || 'Naver API 호출 실패' },
+        { status: res.status },
+      );
+    }
+
+    return NextResponse.json(data.items);
+  } catch (err) {
+    console.error(' 서버 내부 에러:', err);
+
+    return NextResponse.json({ error: '서버 에러' }, { status: 500 });
+  }
+};

--- a/src/app/shop/[id]/page.tsx
+++ b/src/app/shop/[id]/page.tsx
@@ -1,0 +1,5 @@
+import DetailTemplate from '@/components/templates/ShopTemplate/DetailTemplate';
+
+const ProductDetailPage = () => <DetailTemplate />;
+
+export default ProductDetailPage;

--- a/src/app/shop/page.tsx
+++ b/src/app/shop/page.tsx
@@ -1,0 +1,5 @@
+import ShopTemplate from '@/components/templates/ShopTemplate';
+
+const ShopPage = () => <ShopTemplate />;
+
+export default ShopPage;

--- a/src/components/atoms/SelectedChips.tsx
+++ b/src/components/atoms/SelectedChips.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { Chip } from '@nextui-org/react';
+
+interface Props {
+  items: string[];
+  onRemove: (item: string) => void;
+}
+
+const SelectedChips = ({ items, onRemove }: Props) => (
+  <div className="flex flex-wrap gap-2">
+    {items.map((item) => (
+      <Chip
+        key={item}
+        className="bg-mono_900 text-mono_000 text-sm"
+        radius="sm"
+        variant="solid"
+        onClose={() => onRemove(item)}
+      >
+        {item}
+      </Chip>
+    ))}
+  </div>
+);
+
+export default SelectedChips;

--- a/src/components/templates/ShopTemplate/DetailTemplate.tsx
+++ b/src/components/templates/ShopTemplate/DetailTemplate.tsx
@@ -1,0 +1,171 @@
+'use client';
+
+import { useParams } from 'next/navigation';
+import Image from 'next/image';
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import {
+  HeartIcon as HeartOutline,
+  ShareIcon,
+} from '@heroicons/react/24/outline';
+import { HeartIcon as HeartSolid } from '@heroicons/react/24/solid';
+
+import { fetchNaverShopping } from '@/apis/naverShoppingApi';
+import { NaverProduct } from '@/types/naver';
+import Star from '@/components/molecules/StarGroup';
+
+const ProductDetailPage = () => {
+  const { id } = useParams();
+  const [product, setProduct] = useState<NaverProduct | null>(null);
+  const [relatedProducts, setRelatedProducts] = useState<NaverProduct[]>([]);
+  const [liked, setLiked] = useState(false);
+
+  useEffect(() => {
+    if (!id || typeof id !== 'string') return;
+
+    const decoded = decodeURIComponent(id);
+    const [query, indexStr] = decoded.split('_');
+    const index = parseInt(indexStr, 10);
+
+    const fetchData = async () => {
+      const data: NaverProduct[] = await fetchNaverShopping(query, 1, 100);
+
+      if (data?.length && data[index - 1]) {
+        setProduct(data[index - 1]);
+
+        const others = data
+          .filter((_, i: number) => i !== index - 1)
+          .slice(0, 4);
+
+        setRelatedProducts(others);
+      }
+    };
+
+    fetchData();
+  }, [id]);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+      alert('URL이 복사되었습니다!');
+    } catch (e) {
+      console.error(e);
+      alert('URL 복사에 실패했습니다.');
+    }
+  };
+
+  if (!product) return <div className="p-10">불러오는 중...</div>;
+
+  const query = decodeURIComponent(id as string).split('_')[0];
+
+  return (
+    <section className="flex flex-col gap-20 px-10 pt-24 pb-10 max-w-6xl mx-auto">
+      <div className="flex flex-col md:flex-row gap-10">
+        <div className="flex-1 flex justify-center items-center">
+          <Image
+            priority
+            alt="상품 이미지"
+            className="rounded-xl object-cover"
+            height={500}
+            src={product.image}
+            style={{ height: 'auto' }}
+            width={500}
+          />
+        </div>
+
+        <div className="flex-1 flex flex-col justify-between gap-6">
+          <div>
+            <div className="flex items-center gap-2 mb-[13px]">
+              <p>
+                Gym<span className="text-main">M</span>ate
+              </p>
+            </div>
+            <p className="text-sm text-mono_400 mb-[10px]">
+              {product.mallName}
+            </p>
+            <h1
+              dangerouslySetInnerHTML={{ __html: product.title }}
+              className="text-xl font-bold text-mono_900 mb-[10px]"
+            />
+            <Star readonly h="h-5" rate={3} w="w-5" />
+          </div>
+
+          <div className="flex flex-col items-end gap-2">
+            <p className="text-lg font-semibold text-mono_900">
+              가격: {Number(product.lprice).toLocaleString()} 원
+            </p>
+
+            <div className="flex gap-4 flex-wrap justify-end">
+              <button
+                className="w-[240px] h-[48px] flex items-center border border-mono_200 justify-center rounded-md bg-mono_000 text-mono_900 text-sm hover:opacity-90 cursor-pointer gap-2"
+                onClick={() => setLiked(!liked)}
+              >
+                {liked ? (
+                  <HeartSolid className="w-4 h-4 text-main" />
+                ) : (
+                  <HeartOutline className="w-4 h-4" />
+                )}
+                찜하기
+              </button>
+              <button
+                className="w-[240px] h-[48px] flex items-center border border-mono_200 justify-center rounded-md bg-mono_000 text-mono_900 text-sm hover:opacity-90 cursor-pointer gap-2"
+                onClick={handleCopy}
+              >
+                <ShareIcon className="w-4 h-4" /> 공유하기
+              </button>
+              <a
+                className="w-[495px] h-[48px] flex items-center justify-center rounded-md bg-main text-white text-sm hover:opacity-90 transition"
+                href={product.link}
+                rel="noreferrer"
+                target="_blank"
+              >
+                네이버에서 구매하기
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {relatedProducts.length > 0 && (
+        <div className="ml-2">
+          <h2 className="font-point text-2xl font-bold mb-[25px] text-mono_900">
+            추천 상품
+          </h2>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-10">
+            {relatedProducts.map((item, i) => {
+              const itemUrl = `/shop/${encodeURIComponent(`${query}_${i + 1}`)}`;
+
+              return (
+                <Link
+                  key={`item-${i}`}
+                  className="flex flex-col items-start hover:shadow-md transition w-[230px]"
+                  href={itemUrl}
+                >
+                  <Image
+                    alt="관련 상품 이미지"
+                    className="rounded object-cover w-[230px] h-[230px]"
+                    height={230}
+                    src={item.image}
+                    width={230}
+                  />
+                  <p
+                    dangerouslySetInnerHTML={{ __html: item.title }}
+                    className="text-sm font-medium text-mono_900 mt-2 leading-tight"
+                  />
+                  <div className="flex flex-col w-full items-end mt-2 px-[10px]">
+                    <p className="text-xs text-mono_400">{item.mallName}</p>
+                    <p className="text-sm font-semibold text-mono_900">
+                      {Number(item.lprice).toLocaleString()} 원
+                    </p>
+                  </div>
+                </Link>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+};
+
+export default ProductDetailPage;

--- a/src/components/templates/ShopTemplate/FilterCheckboxList.tsx
+++ b/src/components/templates/ShopTemplate/FilterCheckboxList.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { Checkbox } from '@nextui-org/react';
+
+interface Props {
+  options: string[];
+  selected: string[];
+  onChange: (selected: string[]) => void;
+}
+
+const FilterCheckboxList = ({ options, selected, onChange }: Props) => (
+  <div className="flex flex-col gap-1">
+    {options.map((option) => (
+      <Checkbox
+        key={option}
+        className="text-sm"
+        isSelected={selected.includes(option)}
+        radius="sm"
+        size="sm"
+        onValueChange={(checked) =>
+          onChange(
+            checked
+              ? [...selected, option]
+              : selected.filter((i) => i !== option),
+          )
+        }
+      >
+        {option}
+      </Checkbox>
+    ))}
+  </div>
+);
+
+export default FilterCheckboxList;

--- a/src/components/templates/ShopTemplate/FilterSidebar.tsx
+++ b/src/components/templates/ShopTemplate/FilterSidebar.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { useState } from 'react';
+import { Input } from '@nextui-org/react';
+
+import SelectedChips from '@/components/atoms/SelectedChips';
+import FilterCheckboxList from '@/components/templates/ShopTemplate/FilterCheckboxList';
+
+const brandList = [
+  '아이워너',
+  '바디엑스',
+  '앱킨',
+  '이고진',
+  '핏에이블',
+  '반석',
+];
+
+const categoryList = [
+  '하체근력운동기구',
+  '전동운동기구',
+  '스쿼트운동기구',
+  '근력운동기구',
+  '가방',
+  '기타 용품',
+];
+
+interface Props {
+  selectedBrands: string[];
+  setSelectedBrands: (list: string[]) => void;
+  selectedCategories: string[];
+  setSelectedCategories: (list: string[]) => void;
+}
+
+const FilterSidebar = ({
+  selectedBrands,
+  setSelectedBrands,
+  selectedCategories,
+  setSelectedCategories,
+}: Props) => {
+  const [brandSearch, setBrandSearch] = useState('');
+  const [categorySearch, setCategorySearch] = useState('');
+
+  const handleReset = () => {
+    setSelectedBrands([]);
+    setSelectedCategories([]);
+  };
+
+  const handleRemove = (item: string) => {
+    setSelectedBrands((prev) => prev.filter((b) => b !== item));
+    setSelectedCategories((prev) => prev.filter((c) => c !== item));
+  };
+
+  return (
+    <aside className="w-[250px] p-4 rounded-xl shadow bg-mono_000">
+      {/* 선택된 옵션 */}
+      <div className="mb-6">
+        <div className="flex justify-between items-center mb-2">
+          <span className="font-bold text-sm">선택된 옵션</span>
+          <button className="text-xs text-mono_400" onClick={handleReset}>
+            ↻
+          </button>
+        </div>
+        <SelectedChips
+          items={[...selectedBrands, ...selectedCategories]}
+          onRemove={handleRemove}
+        />
+      </div>
+
+      {/* 브랜드 필터 */}
+      <div className="mb-6">
+        <p className="font-bold text-sm mb-2">브랜드</p>
+        <Input
+          className="mb-2"
+          placeholder="브랜드 입력"
+          radius="sm"
+          size="sm"
+          value={brandSearch}
+          onChange={(e) => setBrandSearch(e.target.value)}
+        />
+        <FilterCheckboxList
+          options={brandList.filter((b) => b.includes(brandSearch))}
+          selected={selectedBrands}
+          onChange={setSelectedBrands}
+        />
+      </div>
+
+      {/* 카테고리 필터 */}
+      <div>
+        <p className="font-bold text-sm mb-2">카테고리</p>
+        <Input
+          className="mb-2"
+          placeholder="카테고리 입력"
+          radius="sm"
+          size="sm"
+          value={categorySearch}
+          onChange={(e) => setCategorySearch(e.target.value)}
+        />
+        <FilterCheckboxList
+          options={categoryList.filter((c) => c.includes(categorySearch))}
+          selected={selectedCategories}
+          onChange={setSelectedCategories}
+        />
+      </div>
+    </aside>
+  );
+};
+
+export default FilterSidebar;

--- a/src/components/templates/ShopTemplate/ProductList.tsx
+++ b/src/components/templates/ShopTemplate/ProductList.tsx
@@ -1,0 +1,200 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { useSearchParams, useRouter } from 'next/navigation';
+import Image from 'next/image';
+import Link from 'next/link';
+
+import { fetchNaverShopping } from '@/apis/naverShoppingApi';
+import { NaverProduct } from '@/types/naver';
+import Star from '@/components/molecules/StarGroup';
+
+const PRODUCTS_PER_PAGE = 10;
+
+interface Props {
+  selectedBrands: string[];
+  selectedCategories: string[];
+}
+
+const ProductList = ({ selectedBrands, selectedCategories }: Props) => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const queryParam = searchParams.get('query') || '헬스';
+  const brandParam = searchParams.get('brand') || '';
+  const categoryParam = searchParams.get('category') || '';
+
+  const [products, setProducts] = useState<NaverProduct[]>([]);
+  const [page, setPage] = useState(1);
+  const [hasMore, setHasMore] = useState(true);
+  const [loading, setLoading] = useState(false);
+  const didFetchMap = useRef<Record<number, boolean>>({});
+
+  const query = categoryParam || queryParam;
+  const brand = brandParam;
+  const category = categoryParam;
+
+  useEffect(() => {
+    const searchParams = new URLSearchParams();
+
+    if (selectedBrands[0]) searchParams.set('brand', selectedBrands[0]);
+    if (selectedCategories[0]) {
+      searchParams.set('category', selectedCategories[0]);
+    } else {
+      searchParams.set('query', queryParam);
+    }
+    router.push(`/shop?${searchParams.toString()}`);
+  }, [selectedBrands, selectedCategories]);
+
+  const getData = async (currentPage: number) => {
+    if (didFetchMap.current[currentPage]) return;
+
+    didFetchMap.current[currentPage] = true;
+
+    try {
+      setLoading(true);
+
+      const start = 1;
+      const items = await fetchNaverShopping(query, start, 100);
+
+      if (items.length === 0) {
+        setHasMore(false);
+
+        return;
+      }
+
+      const normalizedItems = items.map((item: NaverProduct, idx: number) => ({
+        ...item,
+        id: `${encodeURIComponent(query)}_${idx + 1}`,
+        brand: extractBrand(item.title),
+        category3: extractCategory(item.title),
+      }));
+
+      setProducts(normalizedItems);
+    } catch (error) {
+      console.error('Naver API 호출 실패:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    setProducts([]);
+    setPage(1);
+    setHasMore(true);
+    didFetchMap.current = {};
+    getData(1);
+  }, [query, brand]);
+
+  const handleLoadMore = () => {
+    if (hasMore && !loading) {
+      setPage((prev) => prev + 1);
+    }
+  };
+
+  const filtered = products.filter((product) => {
+    const b = product.brand?.trim() || '';
+    const c = product.category3?.trim() || '';
+
+    const brandMatch = !brand || b === brand;
+    const categoryMatch = !category || c === category;
+
+    return brandMatch && categoryMatch;
+  });
+
+  return (
+    <div className="flex flex-col items-center w-full max-w-[1440px] px-8 mx-auto">
+      <div className="grid grid-cols-2 gap-10 w-full">
+        {filtered
+          .slice(0, page * PRODUCTS_PER_PAGE)
+          .map(({ title, image, lprice, mallName, id }, i) => (
+            <Link
+              key={`${title}-${i}`}
+              className="flex w-full bg-mono_000 rounded-xl shadow hover:shadow-lg transition overflow-hidden"
+              href={`/shop/${id}`}
+            >
+              <div className="shrink-0 w-[273px] h-[263px] relative self-stretch">
+                <Image
+                  fill
+                  alt="상품 이미지"
+                  className="object-cover rounded"
+                  priority={i === 0}
+                  sizes="(max-width: 768px) 100vw, 273px"
+                  src={image}
+                />
+              </div>
+
+              <div className="flex flex-col justify-between py-4 px-5 flex-1">
+                <div className="flex flex-col justify-between h-full">
+                  <div className="mb-[10px]">
+                    <p className="text-[12px] text-mono_400 mb-1">{mallName}</p>
+                    <p
+                      dangerouslySetInnerHTML={{ __html: title }}
+                      className="text-xs font-semibold text-mono_800 mb-2 line-clamp-2"
+                    />
+                    <Star readonly h="h-4" rate={3} w="w-4" />
+                  </div>
+
+                  <div className="mt-[10px]">
+                    <p className="text-base font-bold text-mono_900 mb-3 text-end">
+                      {Number(lprice).toLocaleString()} 원
+                    </p>
+                    <div className="flex justify-end">
+                      <button className="w-[170px] h-[37px] rounded-md bg-main text-white text-sm hover:opacity-90 transition dark:text-white">
+                        구매하러가기
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </Link>
+          ))}
+      </div>
+
+      {hasMore && filtered.length > page * PRODUCTS_PER_PAGE && (
+        <div className="flex justify-center w-full pb-8">
+          <button
+            className="w-[290px] h-[37px] mt-[50px] mb-[200px] rounded-md bg-main text-white text-sm hover:opacity-90 transition"
+            disabled={loading}
+            onClick={handleLoadMore}
+          >
+            {loading ? '불러오는 중...' : '더보기'}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+const extractBrand = (title: string): string => {
+  const brandCandidates = [
+    '아이워너',
+    '바디엑스',
+    '앱킨',
+    '이고진',
+    '핏에이블',
+    '반석',
+    '아디다스',
+  ];
+
+  return brandCandidates.find((brand) => title.includes(brand)) || '';
+};
+
+const extractCategory = (title: string): string => {
+  const categoryMap: Record<string, string> = {
+    하체근력운동기구: '하체근력운동기구',
+    전동운동기구: '전동운동기구',
+    스쿼트운동기구: '스쿼트운동기구',
+    근력운동기구: '근력운동기구',
+    가방: '가방',
+    기타용품: '기타 용품',
+  };
+
+  const found = Object.entries(categoryMap).find(([keyword]) =>
+    title.includes(keyword),
+  );
+
+  return found?.[1] || '';
+};
+
+export default ProductList;

--- a/src/components/templates/ShopTemplate/index.tsx
+++ b/src/components/templates/ShopTemplate/index.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useState } from 'react';
+
+import FilterSidebar from '@/components/templates/ShopTemplate/FilterSidebar';
+import ProductList from '@/components/templates/ShopTemplate/ProductList';
+
+const ShopTemplate = () => {
+  const [selectedBrands, setSelectedBrands] = useState<string[]>([]);
+  const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
+
+  return (
+    <div className="flex px-10 gap-10 w-full max-w-[1440px] mx-auto pt-[100px] min-h-[80vh]">
+      <div className="w-[280px] shrink-0">
+        <FilterSidebar
+          selectedBrands={selectedBrands}
+          selectedCategories={selectedCategories}
+          setSelectedBrands={setSelectedBrands}
+          setSelectedCategories={setSelectedCategories}
+        />
+      </div>
+
+      <div className="flex-1 bg-mono_000 rounded-xl shadow-inner min-h-[500px]">
+        <ProductList
+          selectedBrands={selectedBrands}
+          selectedCategories={selectedCategories}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default ShopTemplate;

--- a/src/types/naver.d.ts
+++ b/src/types/naver.d.ts
@@ -1,0 +1,10 @@
+export interface NaverProduct {
+  title: string;
+  link: string;
+  image: string;
+  lprice: string;
+  mallName: string;
+  id?: string;
+  brand?: string;
+  category3?: string;
+}


### PR DESCRIPTION
# 📝 제목

shop(feat) : 상품 샵 퍼블리싱 및 aip 연동

---

## 🔘 Part

- shop(feat)

---

## 🔎 작업 내용

- 상품샵 퍼블리싱 및 api 연동
- Naver Open API 호출을 직접 프론트에서 하지 않고, Next.js app/api 라우트를 통해 서버 측에서 호출하는 proxy 방식으로 처리했습니다.

-  적용 이유
1 .보안상 이유로 클라이언트에서 직접 Client ID/Secret 노출을 막기 위해

- Naver Open API는 X-Naver-Client-Id, X-Naver-Client-Secret 헤더를 필수로 요구함

- 이를 클라이언트에 노출할 경우 보안상 매우 취약해지므로, 서버 측에서 호출하도록 분리

2. CORS 회피 목적

- 일부 환경에서 클라이언트 → Naver API 직접 호출 시 CORS 에러 발생 가능성 있음

- 서버가 대신 호출해주는 proxy 방식으로 안정성 확보



---

## 🖼️ 이미지 첨부
![screencapture-localhost-3000-shop-2025-04-03-20_04_18](https://github.com/user-attachments/assets/3f00b960-3230-4723-8dbd-d97c3ab61790)

![screencapture-localhost-3000-shop-9-2025-04-03-20_03_58](https://github.com/user-attachments/assets/f65c6a6d-73d3-42eb-817a-4a0837f17327)

---

## 🔄 체크리스트

- [x] 기존 기능 영향 없음
- [x] 실행 문제 없음
- [x] 테스트 완료

---

## 🙏 리뷰 요청 사항

- api 키 .env 에 작성 부탁드립니다.

---

## 🔧 앞으로의 과제

- 빌드전 , 배포 에러 수정 + 파일 이름 교체 예정

---

## ➕ 이슈 링크

- #24 (자동 링크)

---
